### PR TITLE
Fix undefined reference

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -28,6 +28,9 @@
 #ifndef __APPLE__
 #include <features.h>
 #endif
+#ifdef __linux__
+#include <sys/sysmacros.h>
+#endif
 #include <inttypes.h>
 
 #ifndef PROGRAM_NAME


### PR DESCRIPTION
Include `sys/sysmacros.h` for linux to suppress undefined reference issue.

```
jffs2extract.c: In function ‘do_print’:
jffs2extract.c:352:41: warning: implicit declaration of function ‘major’ [-Wimplicit-function-declaration]
         if(verbose) printf("%4d, %3d ", major(rdev), minor(rdev));
                                         ^~~~~
jffs2extract.c:352:54: warning: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Wimplicit-function-declaration]
         if(verbose) printf("%4d, %3d ", major(rdev), minor(rdev));
                                                      ^~~~~
                                                      mknod
cc -c -Iinclude minilzo.c -o minilzo.o
cc   jffs2extract.o minilzo.o  -lz -o jffs2extract
/usr/bin/ld: jffs2extract.o: in function `do_print':
jffs2extract.c:(.text+0xe39): undefined reference to `minor'
/usr/bin/ld: jffs2extract.c:(.text+0xe4c): undefined reference to `major'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: jffs2extract] Error 1
```